### PR TITLE
Add new span annotations flag

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -144,6 +144,7 @@ function ConvertRequestAssistantToCommentAnalyzer(aRequest: IAssistantRequest, r
     requestedAttributes: config.get('attributeRequests'),
     languages: ['en'],
     clientToken: config.get('userAgent') + '_request' + reqId,
+    spanAnnotations: true,
   };
   if (aRequest.article && aRequest.article.plainText) {
     acRequest.context.entries.push({text: aRequest.article.plainText});


### PR DESCRIPTION
This preserves the existing behavior, as osmod expects annotated spans.
Currently these are enabled in a per-model fashion.
Note that the spans will potentially be different as the splitting algorithm will be
chosen outside of the model definition, by the analyzer.